### PR TITLE
Add DialogTrigger import to AdminDashboard

### DIFF
--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -25,6 +25,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import {
   Users,


### PR DESCRIPTION
Add DialogTrigger to the existing dialog component imports in AdminDashboard.tsx.

This change adds DialogTrigger to the import statement from "@/components/ui/dialog" alongside the other dialog-related components.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/5cb41b52217d4269be4d6938888dcc23/orbit-haven)

👀 [Preview Link](https://5cb41b52217d4269be4d6938888dcc23-orbit-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5cb41b52217d4269be4d6938888dcc23</projectId>-->
<!--<branchName>orbit-haven</branchName>-->