### PR TITLE
Fix notification clicks causing logout, add navigation

### DIFF
--- a/client/components/NotificationBell.tsx
+++ b/client/components/NotificationBell.tsx
@@ -351,7 +351,8 @@ export default function NotificationBell() {
               className="w-full"
               onClick={() => {
                 setIsOpen(false);
-                // You could navigate to a full notifications page here
+                // Navigate to settings or a dedicated notifications page
+                navigate("/settings");
               }}
             >
               View All Notifications

--- a/client/components/NotificationBell.tsx
+++ b/client/components/NotificationBell.tsx
@@ -234,8 +234,9 @@ export default function NotificationBell() {
 
   const handleNotificationClick = (notification: Notification) => {
     markAsRead(notification.id);
+    setIsOpen(false); // Close the popover
     if (notification.actionUrl) {
-      window.location.href = notification.actionUrl;
+      navigate(notification.actionUrl);
     }
   };
 

--- a/client/components/NotificationBell.tsx
+++ b/client/components/NotificationBell.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Popover,
   PopoverContent,

--- a/client/components/NotificationBell.tsx
+++ b/client/components/NotificationBell.tsx
@@ -33,6 +33,7 @@ interface Notification {
 
 export default function NotificationBell() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [isOpen, setIsOpen] = useState(false);
 


### PR DESCRIPTION
## Purpose
Fix notification bell functionality where clicking on notifications was causing users to log out instead of navigating to the intended task/page. The user requested that notification clicks should properly navigate to tasks without logging out.

## Code changes
- **Added React Router navigation**: Imported `useNavigate` hook and replaced `window.location.href` with `navigate()` to prevent page reloads that were causing logout issues
- **Improved popover behavior**: Added `setIsOpen(false)` to close the notification popover when a notification is clicked
- **Enhanced "View All Notifications" button**: Updated to navigate to `/settings` page instead of being a placeholder action

These changes ensure notifications work as expected without disrupting user sessions.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/5cb41b52217d4269be4d6938888dcc23/nova-sanctuary)

👀 [Preview Link](https://5cb41b52217d4269be4d6938888dcc23-nova-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5cb41b52217d4269be4d6938888dcc23</projectId>-->
<!--<branchName>nova-sanctuary</branchName>-->